### PR TITLE
Emojify contents in gh-pages

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   },
   "devDependencies": {
     "coffee-script": "^1.10.0",
+    "emoji-images": "^0.1.1",
     "gulp": "^3.9.1",
     "gulp-count-stat": "^1.0.0",
     "gulp-gh-pages": "^0.5.4",
@@ -21,6 +22,7 @@
     "gulp-rename": "^1.2.2",
     "gulp-replace": "^0.5.4",
     "gulp-scan": "^0.1.4",
+    "gulp-sequence": "^0.4.5",
     "gulp-textlint": "^1.2.0",
     "gulp-util": "^3.0.7",
     "gulp-webserver": "^0.9.1",

--- a/tasks/lib/emojify.coffee
+++ b/tasks/lib/emojify.coffee
@@ -1,0 +1,17 @@
+_ = require "lodash"
+through = require "through2"
+emoji = require "emoji-images"
+
+module.exports = (options) ->
+  options = _.extend({
+    path: "/magi-hacker/emoji"
+    size: null
+  }, options)
+
+  through.obj (file, enc, done) ->
+    return done(null, file) if file.isNull() or file.isStream()
+
+    content = file.contents.toString()
+    file.contents = new Buffer(emoji(content, options.path, options.size))
+
+    done(null, file)


### PR DESCRIPTION
Convert emojis like `:cat:` to `<img>` tags in text files.
