### PR TITLE
Add `--now` option to `gulp publish` task

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "textlint": "^6.0.3",
     "textlint-rule-general-novel-style-ja": "^1.3.0",
     "textlint-rule-no-start-duplicated-conjunction": "^1.0.7",
-    "yamljs": "^0.2.6"
+    "yamljs": "^0.2.6",
+    "yargs": "^4.7.1"
   }
 }

--- a/tasks/publish.coffee
+++ b/tasks/publish.coffee
@@ -3,8 +3,11 @@ gulp = require "gulp"
 gulpIf = require "gulp-if"
 webserver = require "gulp-webserver"
 through = require "through2"
+yargs = require "yargs"
 latest = require "./lib/latest"
 novelous = require "./lib/novelous"
+
+argv = yargs.argv
 
 gulp.task "publish:html", ["build"], ->
   gulp.src "./out/{narou,kakuyomu}/**/*.txt"
@@ -19,7 +22,7 @@ gulp.task "publish:html", ["build"], ->
         novelId: "815110"
       kakuyomu:
         novelId: "4852201425154996024"
-    time: nearestDateAtHour(18).toISOString()
+    time: nearestDateAtHour(18).toISOString() unless argv.now
   )
   .pipe gulp.dest "./out/publish"
 


### PR DESCRIPTION
`--now` option omits `time` parameter from publishing.
